### PR TITLE
Task: Build number as part of package identification

### DIFF
--- a/docs/doc/changes.rst
+++ b/docs/doc/changes.rst
@@ -43,9 +43,10 @@ Rather we work on something else?  Just let us know!
 
 Backlog:
 
-  * Bug: Error message during package installation: ERROR: Failed building wheel for treelib
-  * Task: Test out current PyPI release to see how it works, and identify issues.
-  * Task: Update versions for merge to master.
+  * |in-progress| Bug: Error message during package installation: ERROR: Failed building wheel for treelib
+  * |in-progress| Task: Test out current PyPI release to see how it works, and identify issues.
+  * |in-progress| Task: Build number as part of packge identification
+  * Task: Update semantic patch version for merge to master.
   * Task: Automate releases for merge to master.
   * Story Improve Application of Continuous Integration / Continuous Deployment.
   * Add a progress list directive.

--- a/docs/doc/changes.rst
+++ b/docs/doc/changes.rst
@@ -44,7 +44,7 @@ Rather we work on something else?  Just let us know!
 Backlog:
 
   * Bug: Error message during package installation: ERROR: Failed building wheel for treelib
-  * Task: Test out current PyPi release to see how it works, and identify issues.
+  * Task: Test out current PyPI release to see how it works, and identify issues.
   * Task: Update versions for merge to master.
   * Task: Automate releases for merge to master.
   * Story Improve Application of Continuous Integration / Continuous Deployment.
@@ -150,7 +150,7 @@ Done:
   * |done| 2021-01-01 11:22 Task: First pass at displaying USB device tree with Jinja2 template include.
   * |done| 2020-12-31 19:30 Spike: Try to use Sphinx to generate a styled base for a Jinja2 template.
   * |done| 2020-12-30 20:13 Task: Create a verbose mode for the astutus-usb-tree
-  * |done| 2020-12-29 19:13 Epic: Get package available on PyPi
+  * |done| 2020-12-29 19:13 Epic: Get package available on PyPI
   * |done| 2020-12-29 18:17 Task: Create the docstring for the DeviceAliases class.
   * |done| 2020-12-29 14:51 Task: Create an initial pass for module docstring for astutus.usb.tree
   * |done| 2020-12-29 12:00 Task: Update for autodocs for all modules.

--- a/docs/doc/maintanence/developer_notes.rst
+++ b/docs/doc/maintanence/developer_notes.rst
@@ -9,11 +9,11 @@ Steps:
 
   * Start using GitHub Automation
 
-  * Start updating PyPi with each merge to "Master"
+  * Start updating PyPI with each merge to "Master"
 
   * Automate versioning for developer versus production builds
 
-  * Work on automated testing for gatekeeping prior to PyPi publication.
+  * Work on automated testing for gatekeeping prior to PyPI publication.
 
   * Backfill automated testing for USB functionality, that can be run inside GitHub
 
@@ -67,7 +67,7 @@ At this time, manual upload worked:
   https://pypi.org/project/astutus/0.1.8/
   (venv) rich@wendy:~/src/github.com/rich-dobbs-13440/astutus/packaging/dist$
 
-Changed the password on PyPi to a truely random generated on Wendy using:
+Changed the password on PyPI to a truely random generated on Wendy using:
 
 .. code-block:: console
 

--- a/docs/doc/maintanence/packaging.rst
+++ b/docs/doc/maintanence/packaging.rst
@@ -4,8 +4,8 @@ Packaging
 Build
 -----
 
-At this time, the building is being done on Wendy (a desktop 
-machine that I built in 2014).  It is currently running 
+At this time, the building is being done on Wendy (a desktop
+machine that I built in 2014).  It is currently running
 Linux Mint 20 (Ulyana) with the Cinnamon desktop.
 
 In theory, the process is:
@@ -37,7 +37,7 @@ Should be discussed.
 Publication
 -----------
 
-The aim is to publish to PyPi.  Working at getting things good
+The aim is to publish to PyPI.  Working at getting things good
 enough for initial publication.  Basically should get
 licensed defined adequately, and minimal command.
 
@@ -54,7 +54,7 @@ sudo apt install twine
 (dist_venv) rich@wendy:~/src/github.com/rich-dobbs-13440/astutus/packaging/dist$ twine upload astutus-0.1.2-py3-none-any.whl
 Uploading distributions to https://upload.pypi.org/legacy/
 Enter your username: rich.dobbs.13440
-Enter your password: 
+Enter your password:
 Uploading astutus-0.1.2-py3-none-any.whl
 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10.5M/10.5M [00:19<00:00, 559kB/s]
 NOTE: Try --verbose to see response content.

--- a/packaging/setup.py
+++ b/packaging/setup.py
@@ -4,19 +4,34 @@ import setuptools.command.develop
 import os
 import os.path
 import re
+import pytz
+import datetime
 
 
 with open("../README.rst", "r") as fh:
     long_description = fh.read()
 
-# Version is in this format:  __version__ = '0.1.5'
+# Use PEP 440 compliant versioning.
+#   * Use a local version label to timestamp build - useful for PyPI publishing.
+#   * At this time, not distinguishing between production and other builds.
+#
+#  Since this code always uses a local version label, this isn't using the final version concept.
+#  For automation purposes, may want to identify git branch as part of local version label in future.
 
+# Version is in this format:  __version__ = '0.1.5'
 with open("../src/astutus/version.py") as fh:
     version_content = fh.read()
 
 pattern = r"__version__\s*=\s*'([^']+)'"
 matches = re.search(pattern, version_content)
-version_string = matches.group(1)
+public_version_string = matches.group(1)
+
+utcmoment = datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
+denvernow = utcmoment.astimezone(pytz.timezone('America/Denver'))
+# Don't use dots within local version label, since then setup tools will strip out leading zeros.
+local_version_label = denvernow.strftime("%Y%m%d%H%M%S")
+
+version_string = f'{public_version_string}+{local_version_label}'
 
 
 # Create list for package data manually, since wildcard are not universally supported


### PR DESCRIPTION
This takes care of package identification, but probably still work needed for publishing repeated versions to PyPI